### PR TITLE
Fixes method call for lang.upcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What if your method was being invoked with a totally different collection and a 
 ```ruby
 collection = ['ruby', 'javascript', 'python', 'objective-c']
 my_collect(collection) do |lang|
-  lang.uppercase
+  lang.upcase
 end
 
 # => ["RUBY", "JAVASCRIPT", "PYTHON", "OBJECTIVE-C"]


### PR DESCRIPTION
In the Readme we are asked to execute:

```ruby
collection = ['ruby', 'javascript', 'python', 'objective-c']
my_collect(collection) do |lang|
  lang.uppercase
end
 
# => ["RUBY", "JAVASCRIPT", "PYTHON", "OBJECTIVE-C"]
```

However `uppercase` is not a [String](https://ruby-doc.org/core/String.html) method, the correct one is `upcase`:

```ruby
collection = ['ruby', 'javascript', 'python', 'objective-c']
my_collect(collection) do |lang|
  lang.upcase
end
 
# => ["RUBY", "JAVASCRIPT", "PYTHON", "OBJECTIVE-C"]
```

Running the previous code `irb` with `uppercase` gives this result:

```
2.4.0 :078 > collection = ['ruby', 'javascript', 'python', 'objective-c']
 => ["ruby", "javascript", "python", "objective-c"] 
2.4.0 :079 > my_collect(collection) do |lang|
2.4.0 :080 >       lang.uppercase
2.4.0 :081?>   end
NoMethodError: undefined method `uppercase' for "ruby":String
	from (irb):80:in `block in irb_binding'
	from (irb):72:in `my_collect'
	from (irb):79
	from /Users/gabriela/.rvm/rubies/ruby-2.4.0/bin/irb:11:in `<main>'
```